### PR TITLE
Fix miscoding in tier column of law_dataset.arff

### DIFF
--- a/Law_school/law_dataset.arff
+++ b/Law_school/law_dataset.arff
@@ -9,7 +9,7 @@
 @attribute fam_inc real
 @attribute male real
 @attribute racetxt {0, 1}
-@attribute tier {0, 1}
+@attribute tier {1, 2, 3, 4, 5, 6}
 @attribute pass_bar {0, 1}
 @data
 9.00,7.00,46.00,2.90,1.02,0.30,1.00,4.00,1.00,1,3,1


### PR DESCRIPTION
The metadata in the ARFF file for the `tier` column are currently wrong, making it impossible to load the dataset. This PR uses the correct values present in that column.